### PR TITLE
Fix package manifest so it grabs the utils directory.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include goose3/resources/images *
 recursive-include goose3/resources/text *
-recursive-include goose3/extractors * recursive-include goose3/utils *
+recursive-include goose3/extractors *
+recursive-include goose3/utils *


### PR DESCRIPTION
There was a missing newline in the manifest file which was preventing all the necessary directories from being packaged in dist for pypi