### PR TITLE
Fix remove files - deux

### DIFF
--- a/goose3/configuration.py
+++ b/goose3/configuration.py
@@ -21,6 +21,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import os
+import uuid
 import tempfile
 
 from goose3.text import StopWords
@@ -102,6 +103,9 @@ class Configuration(object):
 
         # set the local storage path
         # make this configurable
+        self._local_storage_path = None
+
+        # set the default by calling the setter
         self.local_storage_path = os.path.join(tempfile.gettempdir(), 'goose')
 
         # http timeout
@@ -112,6 +116,17 @@ class Configuration(object):
 
         # Strict mode. Generate exceptions on errors instead of swallowing them
         self.strict = True
+
+    @property
+    def local_storage_path(self):
+        return self._local_storage_path
+
+    @local_storage_path.setter
+    def local_storage_path(self, val):
+        if val is None:
+            self._local_storage_path = None
+        else:
+            self._local_storage_path = os.path.join(os.path.join(val, uuid.uuid4().hex))
 
     def get_parser(self):
         return AVAILABLE_PARSERS[self.parser_class]

--- a/goose3/configuration.py
+++ b/goose3/configuration.py
@@ -26,7 +26,6 @@ import tempfile
 
 from goose3.text import StopWords
 from goose3.parsers import Parser
-from goose3.parsers import ParserSoup
 from goose3.version import __version__
 
 HTTP_DEFAULT_TIMEOUT = 30

--- a/goose3/configuration.py
+++ b/goose3/configuration.py
@@ -103,8 +103,6 @@ class Configuration(object):
 
         # set the local storage path
         # make this configurable
-        self._local_storage_path = None
-
         # set the default by calling the setter
         self.local_storage_path = os.path.join(tempfile.gettempdir(), 'goose')
 

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -195,9 +195,6 @@ class Crawler(object):
             # clean_text
             self.article.cleaned_text = self.formatter.get_formatted_text()
 
-        # cleanup tmp file
-        self.relase_resources()
-
         # return the article
         return self.article
 
@@ -263,12 +260,3 @@ class Crawler(object):
 
     def get_extractor(self):
         return StandardContentExtractor(self.config, self.article)
-
-    def relase_resources(self):
-        path = os.path.join(self.config.local_storage_path, '%s_*' % self.article.link_hash)
-        for fname in glob.glob(path):
-            try:
-                os.remove(fname)
-            except OSError:
-                # TODO better log handeling
-                pass

--- a/goose3/utils/__init__.py
+++ b/goose3/utils/__init__.py
@@ -28,7 +28,7 @@ import codecs
 from urllib.parse import urlparse
 
 # TODO: this is a cyclic import
-import goose3
+import goose3.version as base
 
 
 class BuildURL(object):
@@ -67,8 +67,8 @@ class FileHelper(object):
 
     @classmethod
     def loadResourceFile(self, filename):
-        if not os.path.isabs('filename'):
-            dirpath = os.path.dirname(goose3.__file__)
+        if not os.path.isabs(filename):
+            dirpath = os.path.dirname(base.__file__)
             path = os.path.join(dirpath, 'resources', filename)
         else:
             path = filename

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -37,17 +37,17 @@ class TestTempDir(unittest.TestCase):
         self.assertNotEqual(g.config.local_storage_path, default_local_storage_path)
 
     def test_tmp_overwritten(self):
-        path = '/tmp/goose'
+        path = '/tmp/goose3'
         g = Goose({'local_storage_path': path})
         self.assertTrue(g.config.local_storage_path.startswith(path))
 
     def test_tmp_exists(self):
-        path = '/tmp/goose'
+        path = '/tmp/goose3'
         g = Goose({'local_storage_path': path})
         self.assertTrue(os.path.isdir(path))
 
     def test_tmp_removed_on_close(self):
-        path = '/tmp/goose'
+        path = '/tmp/goose3'
         g = Goose({'local_storage_path': path})
         full_path = g.config.local_storage_path
         self.assertTrue(os.path.isdir(full_path))

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -30,11 +30,27 @@ from goose3 import Goose
 class TestTempDir(unittest.TestCase):
 
     def test_tmp_defaut(self):
+        ''' test that it starts with, but is not equal to the default '''
         g = Goose()
         default_local_storage_path = os.path.join(tempfile.gettempdir(), 'goose')
-        self.assertEqual(g.config.local_storage_path, default_local_storage_path)
+        self.assertTrue(g.config.local_storage_path.startswith(default_local_storage_path))
+        self.assertNotEqual(g.config.local_storage_path, default_local_storage_path)
 
     def test_tmp_overwritten(self):
         path = '/tmp/goose'
         g = Goose({'local_storage_path': path})
-        self.assertEqual(g.config.local_storage_path, path)
+        self.assertTrue(g.config.local_storage_path.startswith(path))
+
+    def test_tmp_exists(self):
+        path = '/tmp/goose'
+        g = Goose({'local_storage_path': path})
+        self.assertTrue(os.path.isdir(path))
+
+    def test_tmp_removed_on_close(self):
+        path = '/tmp/goose'
+        g = Goose({'local_storage_path': path})
+        full_path = g.config.local_storage_path
+        self.assertTrue(os.path.isdir(full_path))
+        g.close()
+        self.assertFalse(os.path.isdir(full_path))
+        self.assertTrue(os.path.isdir(path))


### PR DESCRIPTION
Implementation of option 1 for issue #19 

* Unique sub-folder on each run of goose
* Remove sub-folder and associated files on close

New functionality:
1) `.close()` to clean-up the object (auto called at garbage collection)
2) context manager:
``` python
from goose3 import Goose

with Goose() as g:
    g.extract(url)
```