### PR TITLE
Fix: Relative Image URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Goose will try to extract the following information:
 -  Meta Description
 -  Meta tags
 
-The Python version was rewritten by:
+The Python version was originally rewritten by:
 
 -  Xavier Grangier
 
@@ -39,12 +39,20 @@ LICENSE file for more details.
 Setup
 -----
 
+To install using pip:
+
 .. code-block::
 
-    mkvirtualenv --no-site-packages goose
-    git clone https://github.com/grangier/python-goose.git
-    cd python-goose
-    pip install -r requirements.txt
+    pip install goose3
+
+To install from source:
+
+.. code-block::
+
+    mkvirtualenv --no-site-packages goose3
+    git clone https://github.com/goose3/goose3.git
+    cd goose3
+    pip install -r ./requirements/python
     python setup.py install
 
 Take it for a spin
@@ -179,7 +187,7 @@ class.
     >>> g = Goose({'stopwords_class': StopWordsArabic})
     >>> article = g.extract(url=url)
     >>> print article.cleaned_text[:150]
-    دمشق، سوريا (CNN) -- أكدت جهات سورية معارضة أن فصائل مسلحة معارضة لنظام الرئيس بشار الأسد وعلى صلة بـ"الجيش الحر" تمكنت من السيطرة على مستودعات للأسل
+    دمشق، سوريا (CNN) - أكدت جهات سورية معارضة أن فصائل مسلحة معارضة لنظام الرئيس بشار الأسد وعلى صلة بـ"الجيش الحر" تمكنت من السيطرة على مستودعات للأسل
 
 
 Goose in Korean

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -196,7 +196,7 @@ class Crawler(object):
             self.article.cleaned_text = self.formatter.get_formatted_text()
 
         # cleanup tmp file
-        self.relase_resources()
+        self.release_resources()
 
         # return the article
         return self.article
@@ -264,7 +264,7 @@ class Crawler(object):
     def get_extractor(self):
         return StandardContentExtractor(self.config, self.article)
 
-    def relase_resources(self):
+    def release_resources(self):
         path = os.path.join(self.config.local_storage_path, '%s_*' % self.article.link_hash)
         for fname in glob.glob(path):
             try:

--- a/goose3/extractors/images.py
+++ b/goose3/extractors/images.py
@@ -59,13 +59,6 @@ class ImageExtractor(BaseExtractor):
         # What's the minimum bytes for an image we'd accept is
         self.images_min_bytes = 4000
 
-        # the webpage url that we're extracting content from
-        self.target_url = article.final_url
-
-        # stores a hash of our url for
-        # reference and image processing
-        self.link_hash = article.link_hash
-
         # this lists all the known bad button names that we have
         self.badimages_names_re = re.compile(
             ".html|.gif|.ico|button|twitter.jpg|facebook.jpg|ap_buy_photo"
@@ -335,7 +328,7 @@ class ImageExtractor(BaseExtractor):
         """\
         returns the bytes of the image file on disk
         """
-        return ImageUtils.store_image(self.fetcher, self.link_hash, src, self.config)
+        return ImageUtils.store_image(self.fetcher, self.article.link_hash, src, self.config)
 
     def get_clean_domain(self):
         if self.article.domain:
@@ -400,10 +393,10 @@ class ImageExtractor(BaseExtractor):
         """
         o = urlparse(src)
         # we have a full url
-        if o.hostname:
+        if o.netloc != '':
             return o.geturl()
         # we have a relative url
-        return urljoin(self.target_url, src)
+        return urljoin(self.article.final_url, src)
 
     def load_customesite_mapping(self):
         # TODO

--- a/goose3/utils/__init__.py
+++ b/goose3/utils/__init__.py
@@ -100,9 +100,14 @@ class URLHelper(object):
     @classmethod
     def get_parsing_candidate(self, url_to_crawl):
         # replace shebang is urls
-        final_url = url_to_crawl.replace('#!', '?_escaped_fragment_=') \
-                    if '#!' in url_to_crawl else url_to_crawl
+        if '#!' in url_to_crawl:
+            final_url = url_to_crawl.replace('#!', '?_escaped_fragment_=')
+        else:
+            final_url = url_to_crawl
+
+        # url is only for calculating the link_hash
         url = final_url.encode("utf-8") if isinstance(final_url, str) else final_url
+        
         link_hash = '%s.%s' % (hashlib.md5(url).hexdigest(), time.time())
         return ParsingCandidate(final_url, link_hash)
 

--- a/goose3/utils/__init__.py
+++ b/goose3/utils/__init__.py
@@ -27,8 +27,7 @@ import os
 import codecs
 from urllib.parse import urlparse
 
-# TODO: this is a cyclic import
-import goose3
+import goose3.version as base
 
 
 class BuildURL(object):
@@ -68,7 +67,7 @@ class FileHelper(object):
     @classmethod
     def loadResourceFile(self, filename):
         if not os.path.isabs('filename'):
-            dirpath = os.path.dirname(goose3.__file__)
+            dirpath = os.path.dirname(base.__file__)
             path = os.path.join(dirpath, 'resources', filename)
         else:
             path = filename
@@ -107,7 +106,7 @@ class URLHelper(object):
 
         # url is only for calculating the link_hash
         url = final_url.encode("utf-8") if isinstance(final_url, str) else final_url
-        
+
         link_hash = '%s.%s' % (hashlib.md5(url).hexdigest(), time.time())
         return ParsingCandidate(final_url, link_hash)
 


### PR DESCRIPTION
The issue for #21 is that the image extractor was initialized before the article information was populated. This caused two variables to be `None` or `''` when we expected them to contain a value. By removing the use of the variables and instead using the `self.article` directly resolved this issue. 

Also note, that this resolves #18 as if fixes the logic to generate the correct temporary file names. If/when this is merged, the other related PRs ( #20 and #19)