### PR TITLE
fix find_charset & remove redundant find_pragma

### DIFF
--- a/goose3/text.py
+++ b/goose3/text.py
@@ -41,29 +41,21 @@ def get_encodings_from_content(content):
     """
     if isinstance(content, bytes):
         find_charset = re.compile(
-            br'<meta.*?charset=["\']*(.+?)["\'>]', flags=re.I
-        ).findall
-
-        find_pragma = re.compile(
-            br'<meta.*?content=["\']*;?charset=(.+?)["\'>]', flags=re.I
+            br'<meta.*?charset=["\']*([a-z0-9\-_]+?) *?["\'>]', flags=re.I
         ).findall
 
         find_xml = re.compile(
-            br'^<\?xml.*?encoding=["\']*(.+?)["\'>]'
+            br'^<\?xml.*?encoding=["\']*([a-z0-9\-_]+?) *?["\'>]'
         ).findall
     else:
         find_charset = re.compile(
-            r'<meta.*?charset=["\']*(.+?)["\'>]', flags=re.I
-        ).findall
-
-        find_pragma = re.compile(
-            r'<meta.*?content=["\']*;?charset=(.+?)["\'>]', flags=re.I
+            r'<meta.*?charset=["\']*([a-z0-9\-_]+?) *?["\'>]', flags=re.I
         ).findall
 
         find_xml = re.compile(
-            r'^<\?xml.*?encoding=["\']*(.+?)["\'>]'
+            r'^<\?xml.*?encoding=["\']*([a-z0-9\-_]+?) *?["\'>]'
         ).findall
-    return find_charset(content) + find_pragma(content) + find_xml(content)
+    return find_charset(content) + find_xml(content)
 
 
 def innerTrim(value):

--- a/goose3/text.py
+++ b/goose3/text.py
@@ -47,6 +47,8 @@ def get_encodings_from_content(content):
         find_xml = re.compile(
             br'^<\?xml.*?encoding=["\']*([a-z0-9\-_]+?) *?["\'>]'
         ).findall
+        return [encoding.decode('utf-8') for encoding in
+                find_charset(content) + find_xml(content)]
     else:
         find_charset = re.compile(
             r'<meta.*?charset=["\']*([a-z0-9\-_]+?) *?["\'>]', flags=re.I
@@ -55,7 +57,7 @@ def get_encodings_from_content(content):
         find_xml = re.compile(
             r'^<\?xml.*?encoding=["\']*([a-z0-9\-_]+?) *?["\'>]'
         ).findall
-    return find_charset(content) + find_xml(content)
+        return find_charset(content) + find_xml(content)
 
 
 def innerTrim(value):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""\
+This is a python port of "Goose" orignialy licensed to Gravity.com
+under one or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.
+
+Python port was written by Xavier Grangier for Recrutae
+
+Gravity.com licenses this file
+to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+
+from goose3.text import get_encodings_from_content
+
+
+class TestText(unittest.TestCase):
+
+    def test_get_encodings_from_content(self):
+        self.assertEqual(
+            get_encodings_from_content(
+                '<meta charset=utf-8 " />'),
+            ['utf-8']
+        )
+        self.assertEqual(
+            get_encodings_from_content(
+                '<meta http-equiv="content-type" content="text/html; charset=utf-8 " />'),
+            ['utf-8']
+        )
+        self.assertEqual(
+            get_encodings_from_content(
+                '<meta http-equiv="content-type" content="text/html; charset=utf-8    " />'),
+            ['utf-8']
+        )
+        self.assertEqual(
+            get_encodings_from_content(
+                b'<meta http-equiv="content-type" content="text/html; charset=utf-8 " />'),
+            [b'utf-8']
+        )
+        # without trail spaces
+        self.assertEqual(
+            get_encodings_from_content(
+                '<meta http-equiv="content-type" content="text/html; charset=utf-8" />'),
+            ['utf-8']
+        )
+        self.assertEqual(
+            get_encodings_from_content(
+                b'<meta http-equiv="content-type" content="text/html; charset=utf-8" />'),
+            [b'utf-8']
+        )

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -27,7 +27,7 @@ from goose3.text import get_encodings_from_content
 
 class TestText(unittest.TestCase):
 
-    def test_get_encodings_from_content(self):
+    def test_get_encodings_from_content_with_trail_spaces(self):
         self.assertEqual(
             get_encodings_from_content(
                 '<meta charset=utf-8 " />'),
@@ -46,9 +46,10 @@ class TestText(unittest.TestCase):
         self.assertEqual(
             get_encodings_from_content(
                 b'<meta http-equiv="content-type" content="text/html; charset=utf-8 " />'),
-            [b'utf-8']
+            ['utf-8']
         )
-        # without trail spaces
+
+    def test_get_encodings_from_content_with_out_trail_spaces(self):
         self.assertEqual(
             get_encodings_from_content(
                 '<meta http-equiv="content-type" content="text/html; charset=utf-8" />'),
@@ -57,5 +58,5 @@ class TestText(unittest.TestCase):
         self.assertEqual(
             get_encodings_from_content(
                 b'<meta http-equiv="content-type" content="text/html; charset=utf-8" />'),
-            [b'utf-8']
+            ['utf-8']
         )


### PR DESCRIPTION
* charset value in HTML meta tag may contain trail spaces;
* char encoding should only contain alphabets and _-;
* *? in find_charset will match content=(and other chars) in find_pragma the later is a redundant;
* encoding string should be str in Python 3