### PR TITLE
use for-loop to replace recursive call to deal with multi parsers

### DIFF
--- a/goose3/__init__.py
+++ b/goose3/__init__.py
@@ -121,15 +121,11 @@ class Goose(object):
         self.fetcher = None
 
     def __crawl(self, crawl_candidate):
-        parsers = list(self.config.available_parsers)
-        parsers.remove(self.config.parser_class)
-        try:
-            crawler = Crawler(self.config, self.fetcher)
-            article = crawler.crawl(crawl_candidate)
-        except (UnicodeDecodeError, ValueError) as ex:
-            if parsers:
-                self.config.parser_class = parsers[0]
-                return self.__crawl(crawl_candidate)
-            else:
-                raise ex
-        return article
+        for index, parser in enumerate(self.config.available_parsers, 1):
+            self.config.parser_class = parser
+            try:
+                crawler = Crawler(self.config, self.fetcher)
+                return crawler.crawl(crawl_candidate)
+            except (UnicodeDecodeError, ValueError) as ex:
+                if index == len(self.config.available_parsers):
+                    raise ex

--- a/goose3/configuration.py
+++ b/goose3/configuration.py
@@ -22,15 +22,18 @@ limitations under the License.
 """
 import os
 import tempfile
+from collections import OrderedDict
 
 from goose3.text import StopWords
 from goose3.parsers import Parser, ParserSoup
 from goose3.version import __version__
 
-AVAILABLE_PARSERS = {
-    'lxml': Parser,
-    'soup': ParserSoup,
-}
+AVAILABLE_PARSERS = OrderedDict(
+    [
+        ('lxml', Parser),
+        ('soup', ParserSoup),
+    ]
+)
 
 KNOWN_ARTICLE_CONTENT_PATTERNS = [
     {'attr': 'class', 'value': 'short-story'},


### PR DESCRIPTION
* Code in https://github.com/goose3/goose3/blob/a36aa1710fd930b28bad5db31b323a899db6cdcf/goose3/__init__.py#L124-L125
 Can't remove all parsers(`self.config.available_parsers` never change). So `parsers` always have one element.
If both parser cause ValueError or UnicodeDecodeError, the program will run into endless recurisive.

* Ensure use `lxml` parser at first.