### PR TITLE
Fixed encoding issue for non utf-8 charsets in html

### DIFF
--- a/goose3/utils/encoding.py
+++ b/goose3/utils/encoding.py
@@ -112,7 +112,10 @@ def smart_str(string, encoding='utf-8', strings_only=False, errors='strict'):
     # if isinstance(s, Promise):
     #     return unicode(s).encode(encoding, errors)
     if isinstance(string, str):
-        return string.encode(encoding, errors)
+        try:
+            return string.encode(encoding, errors)
+        except UnicodeEncodeError:
+            return string.encode('utf-8', errors)
     elif not isinstance(string, bytes):
         try:
             return str(string).encode(encoding, errors)


### PR DESCRIPTION
If a valid HTML string is passed as a param to the encode method with a non 'utf-8' encoding such as 'ISO-8859-1' it will cause the parsing of html to break