### PR TITLE
Add known_publish_date_tags to goose configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ install:
 
 script:
     - python setup.py test
+    - flake8 ./goose3

--- a/goose3/__init__.py
+++ b/goose3/__init__.py
@@ -24,7 +24,7 @@ import os
 import weakref
 from tempfile import mkstemp
 
-from goose3.configuration import Configuration
+from goose3.configuration import ArticleContextPattern, Configuration, PublishDatePattern
 from goose3.article import Article  # to make it available for documentation!
 from goose3.image import Image  # to make it available for documentation!
 from goose3.video import Video  # to make it available for documentation!

--- a/goose3/__init__.py
+++ b/goose3/__init__.py
@@ -24,10 +24,10 @@ import os
 import weakref
 from tempfile import mkstemp
 
-from goose3.configuration import ArticleContextPattern, Configuration, PublishDatePattern
-from goose3.article import Article  # to make it available for documentation!
-from goose3.image import Image  # to make it available for documentation!
-from goose3.video import Video  # to make it available for documentation!
+from goose3.configuration import ArticleContextPattern, Configuration, PublishDatePattern  # noqa: F401
+from goose3.article import Article  # noqa: F401 - to make it available for documentation!
+from goose3.image import Image  # noqa: F401 - to make it available for documentation!
+from goose3.video import Video  # noqa: F401 - to make it available for documentation!
 from goose3.crawler import (CrawlCandidate, Crawler)
 from goose3.network import NetworkFetcher
 

--- a/goose3/cleaners.py
+++ b/goose3/cleaners.py
@@ -188,9 +188,9 @@ class DocumentCleaner(object):
                 replace_text = self.tablines_replacements.replaceAll(kid_text)
                 if(len(replace_text)) > 1:
                     previous_sibling_node = self.parser.previousSibling(kid_text_node)
-                    while previous_sibling_node is not None \
-                        and self.parser.getTag(previous_sibling_node) == "a" \
-                        and self.parser.getAttribute(previous_sibling_node, 'grv-usedalready') != 'yes':
+                    while (previous_sibling_node is not None
+                            and self.parser.getTag(previous_sibling_node) == "a"
+                            and self.parser.getAttribute(previous_sibling_node, 'grv-usedalready') != 'yes'):
                         outer = " " + self.parser.outerHtml(previous_sibling_node) + " "
                         replacement_text.append(outer)
                         nodes_to_remove.append(previous_sibling_node)
@@ -202,9 +202,9 @@ class DocumentCleaner(object):
                     replacement_text.append(replace_text)
                     #
                     next_sibling_node = self.parser.nextSibling(kid_text_node)
-                    while next_sibling_node is not None \
-                        and self.parser.getTag(next_sibling_node) == "a" \
-                        and self.parser.getAttribute(next_sibling_node, 'grv-usedalready') != 'yes':
+                    while (next_sibling_node is not None
+                            and self.parser.getTag(next_sibling_node) == "a"
+                            and self.parser.getAttribute(next_sibling_node, 'grv-usedalready') != 'yes'):
                         outer = " " + self.parser.outerHtml(next_sibling_node) + " "
                         replacement_text.append(outer)
                         nodes_to_remove.append(next_sibling_node)

--- a/goose3/configuration.py
+++ b/goose3/configuration.py
@@ -41,6 +41,15 @@ KNOWN_ARTICLE_CONTENT_PATTERNS = [
 ]
 
 
+KNOWN_PUBLISH_DATE_TAGS = [
+    {'attribute': 'property', 'value': 'rnews:datePublished', 'content': 'content'},
+    {'attribute': 'property', 'value': 'article:published_time', 'content': 'content'},
+    {'attribute': 'name', 'value': 'OriginalPublicationDate', 'content': 'content'},
+    {'attribute': 'itemprop', 'value': 'datePublished', 'content': 'datetime'},
+    {'attribute': 'name', 'value': 'published_time_telegram', 'content': 'content'},
+]
+
+
 class Configuration(object):
 
     def __init__(self):
@@ -58,6 +67,7 @@ class Configuration(object):
         # extraction information
         self._local_storage_path = os.path.join(tempfile.gettempdir(), 'goose')
         self._known_context_patterns = KNOWN_ARTICLE_CONTENT_PATTERNS
+        self._known_publish_date_tags = KNOWN_PUBLISH_DATE_TAGS
         self._target_language = 'en'
         self._use_meta_language = True
 
@@ -100,6 +110,28 @@ class Configuration(object):
             self._known_context_patterns = val + self.known_context_patterns
         else:
             self._known_context_patterns.insert(0, val)
+
+    @property
+    def known_publish_date_tags(self):
+        ''' list: The tags to search to find the likely published date
+
+            Note:
+                Each entry must be a dictionary with the following keys: `attribute`, `value`, \
+                and `content`.
+        '''
+        return self._known_publish_date_tags
+
+    @known_publish_date_tags.setter
+    def known_publish_date_tags(self, val):
+        ''' val must be a dictionary or list of dictionaries
+            e.g., {'attrribute': 'name', 'value': 'my-pubdate', 'content': 'datetime'}
+                or [{'attrribute': 'name', 'value': 'my-pubdate', 'content': 'datetime'},
+                    {'attrribute': 'property', 'value': 'pub_time', 'content': 'content'}]
+        '''
+        if isinstance(val, list):
+            self._known_publish_date_tags = val + self.known_publish_date_tags
+        else:
+            self._known_publish_date_tags.insert(0, val)
 
     @property
     def strict(self):

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -137,9 +137,6 @@ class Crawler(object):
         # open graph
         self.article._opengraph = self.opengraph_extractor.extract()
 
-        # publishdate
-        self.article._publish_date = self.publishdate_extractor.extract()
-
         # meta
         metas = self.metas_extractor.extract()
         # print(metas)
@@ -150,6 +147,9 @@ class Crawler(object):
         self.article._meta_encoding = metas['encoding']
         self.article._canonical_link = metas['canonical']
         self.article._domain = metas['domain']
+
+        # publishdate
+        self.article._publish_date = self.publishdate_extractor.extract()
 
         # tags
         self.article._tags = self.tags_extractor.extract()

--- a/goose3/extractors/content.py
+++ b/goose3/extractors/content.py
@@ -42,20 +42,34 @@ class ContentExtractor(BaseExtractor):
     def get_known_article_tags(self):
         nodes = []
         for item in self.config.known_context_patterns:
-            nodes.extend(self.parser.getElementsByTag(self.article.doc, **item))
+            # if this is a domain specific config and the current
+            # article domain does not match the configured domain,
+            # do not use the configured content pattern
+            if item.domain and self.article.domain != item.domain:
+                continue
+
+            nodes.extend(self.parser.getElementsByTag(self.article.doc, tag=item.tag,
+                                                      attr=item.attr, value=item.value))
         if nodes:
             return nodes
         return None
 
     def is_articlebody(self, node):
         for item in self.config.known_context_patterns:
+            # if this is a domain specific config and the current
+            # article domain does not match the configured domain,
+            # do not use the configured content pattern
+            if item.domain and self.article.domain != item.domain:
+                continue
+
             # attribute
-            if "attr" in item and "value" in item:
-                if self.parser.getAttribute(node, item['attr']) == item['value']:
+            if item.attr:
+                if self.parser.getAttribute(node, item.attr) == item.value:
                     return True
+
             # tag
-            if "tag" in item:
-                if node.tag == item['tag']:
+            if item.tag:
+                if node.tag == item.tag:
                     return True
 
         return False

--- a/goose3/extractors/content.py
+++ b/goose3/extractors/content.py
@@ -88,7 +88,8 @@ class ContentExtractor(BaseExtractor):
 
         for node in nodes_to_check:
             text_node = self.parser.getText(node)
-            word_stats = self.stopwords_class(language=self.get_language()).get_stopword_count(text_node)
+            word_stats = self.stopwords_class(
+                    language=self.get_language()).get_stopword_count(text_node)
             high_link_density = self.is_highlink_density(node)
             if word_stats.get_stopword_count() > 2 and not high_link_density:
                 nodes_with_text.append(node)
@@ -114,7 +115,8 @@ class ContentExtractor(BaseExtractor):
                         boost_score = float(5)
 
             text_node = self.parser.getText(node)
-            word_stats = self.stopwords_class(language=self.get_language()).get_stopword_count(text_node)
+            word_stats = self.stopwords_class(
+                    language=self.get_language()).get_stopword_count(text_node)
             upscore = int(word_stats.get_stopword_count() + boost_score)
 
             # parent node
@@ -170,7 +172,8 @@ class ContentExtractor(BaseExtractor):
                 if steps_away >= max_stepsaway_from_node:
                     return False
                 para_text = self.parser.getText(current_node)
-                word_stats = self.stopwords_class(language=self.get_language()).get_stopword_count(para_text)
+                word_stats = self.stopwords_class(
+                        language=self.get_language()).get_stopword_count(para_text)
                 if word_stats.get_stopword_count() > minimum_stopword_count:
                     return True
                 steps_away += 1
@@ -217,7 +220,8 @@ class ContentExtractor(BaseExtractor):
             for first_paragraph in potential_paragraphs:
                 text = self.parser.getText(first_paragraph)
                 if text:  # no len(text) > 0
-                    word_stats = self.stopwords_class(language=self.get_language()).get_stopword_count(text)
+                    word_stats = self.stopwords_class(
+                            language=self.get_language()).get_stopword_count(text)
                     paragraph_score = word_stats.get_stopword_count()
                     sibling_baseline_score = float(.30)
                     high_link_density = self.is_highlink_density(first_paragraph)
@@ -244,7 +248,8 @@ class ContentExtractor(BaseExtractor):
 
         for node in nodes_to_check:
             text_node = self.parser.getText(node)
-            word_stats = self.stopwords_class(language=self.get_language()).get_stopword_count(text_node)
+            word_stats = self.stopwords_class(
+                    language=self.get_language()).get_stopword_count(text_node)
             high_link_density = self.is_highlink_density(node)
             if word_stats.get_stopword_count() > 2 and not high_link_density:
                 paragraphs_number += 1
@@ -371,7 +376,8 @@ class ContentExtractor(BaseExtractor):
         for elm in self.parser.getChildren(node):
             e_tag = self.parser.getTag(elm)
             if e_tag not in parse_tags:
-                if self.is_highlink_density(elm) or self.is_table_and_no_para_exist(elm) or not self.is_nodescore_threshold_met(node, elm):
+                if (self.is_highlink_density(elm) or self.is_table_and_no_para_exist(elm)
+                        or not self.is_nodescore_threshold_met(node, elm)):
                     self.parser.remove(elm)
         return node
 

--- a/goose3/extractors/publishdate.py
+++ b/goose3/extractors/publishdate.py
@@ -27,9 +27,14 @@ from goose3.extractors import BaseExtractor
 class PublishDateExtractor(BaseExtractor):
     def extract(self):
         for known_meta_tag in self.config.known_publish_date_tags:
+            # if this is a domain specific config and the current
+            # article domain does not match the configured domain,
+            # do not use the configured publish date pattern
+            if known_meta_tag.domain and known_meta_tag.domain != self.article.domain:
+                continue
             meta_tags = self.parser.getElementsByTag(self.article.doc,
-                                                     attr=known_meta_tag['attribute'],
-                                                     value=known_meta_tag['value'])
+                                                     attr=known_meta_tag.attr,
+                                                     value=known_meta_tag.value)
             if meta_tags:
-                return self.parser.getAttribute(meta_tags[0], known_meta_tag['content'])
+                return self.parser.getAttribute(meta_tags[0], known_meta_tag.content)
         return None

--- a/goose3/extractors/publishdate.py
+++ b/goose3/extractors/publishdate.py
@@ -23,18 +23,10 @@ limitations under the License.
 
 from goose3.extractors import BaseExtractor
 
-KNOWN_PUBLISH_DATE_TAGS = [
-    {'attribute': 'property', 'value': 'rnews:datePublished', 'content': 'content'},
-    {'attribute': 'property', 'value': 'article:published_time', 'content': 'content'},
-    {'attribute': 'name', 'value': 'OriginalPublicationDate', 'content': 'content'},
-    {'attribute': 'itemprop', 'value': 'datePublished', 'content': 'datetime'},
-    {'attribute': 'name', 'value': 'published_time_telegram', 'content': 'content'},
-]
-
 
 class PublishDateExtractor(BaseExtractor):
     def extract(self):
-        for known_meta_tag in KNOWN_PUBLISH_DATE_TAGS:
+        for known_meta_tag in self.config.known_publish_date_tags:
             meta_tags = self.parser.getElementsByTag(self.article.doc,
                                                      attr=known_meta_tag['attribute'],
                                                      value=known_meta_tag['value'])

--- a/goose3/outputformatters.py
+++ b/goose3/outputformatters.py
@@ -141,9 +141,9 @@ class OutputFormatter(object):
             tag = self.parser.getTag(elm)
             text = self.parser.getText(elm)
             stop_words = self.stopwords_class(language=self.get_language()).get_stopword_count(text)
-            if (tag != 'br' or text != '\\r') and stop_words.get_stopword_count() < 3 \
-                and len(self.parser.getElementsByTag(elm, tag='object')) == 0 \
-                and len(self.parser.getElementsByTag(elm, tag='embed')) == 0:
+            if ((tag != 'br' or text != '\\r') and stop_words.get_stopword_count() < 3
+                    and len(self.parser.getElementsByTag(elm, tag='object')) == 0
+                    and len(self.parser.getElementsByTag(elm, tag='embed')) == 0):
                 self.parser.remove(elm)
             # TODO
             # check if it is in the right place

--- a/goose3/utils/__init__.py
+++ b/goose3/utils/__init__.py
@@ -22,42 +22,10 @@ limitations under the License.
 """
 import time
 import hashlib
-import re
 import os
 import codecs
-from urllib.parse import urlparse
 
 import goose3.version as base
-
-
-class BuildURL(object):
-    # TODO: This class is ever used... I recommend removing it!
-    def __init__(self, url, finalurl=None):
-        self.url = url
-        self.finalurl = finalurl
-
-    def getHostname(self, o):
-        if o.hostname:
-            return o.hotname
-        elif self.finalurl:
-            tmp = urlparse(self.finalurl)
-            if tmp.hostname:
-                return tmp.hostname
-        return None
-
-    def getScheme(self, o):
-        if o.scheme:
-            return o.scheme
-        elif self.finalurl:
-            tmp = urlparse(self.finalurl)
-            if tmp.scheme:
-                return tmp.scheme
-        return 'http'
-
-    def getUrl(self):
-        url_obj = urlparse(self.url)
-        scheme = self.getScheme(url_obj)
-        hostname = self.getHostname(url_obj)
 
 
 class FileHelper(object):

--- a/requirements/python-dev
+++ b/requirements/python-dev
@@ -1,1 +1,2 @@
+flake8
 requests_mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ description-file = README.rst
 
 [pep8]
 max-line-length = 120
+
+[flake8]
+max-line-length = 120

--- a/tests/data/content/test_pattern_config.html
+++ b/tests/data/content/test_pattern_config.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+    <div>
+      <p>
+        This should not be included.
+      </p>
+    </div>
+    <div class='super-rare-article-tag'>
+      <p>
+        This is the real content.
+      </p>
+    </div>
+  </body>
+</html>

--- a/tests/data/content/test_pattern_config.json
+++ b/tests/data/content/test_pattern_config.json
@@ -1,0 +1,6 @@
+{
+    "url": "http://example.com/test_pattern_config.html",
+    "expected": {
+        "cleaned_text": "This is the real content"
+    }
+}

--- a/tests/data/publishdate/test_publish_date_config.html
+++ b/tests/data/publishdate/test_publish_date_config.html
@@ -1,0 +1,7 @@
+<html>
+    <head>
+        <meta name="super-rare-date-tag" value="2014-11-23T15:00:00+04:00"/>
+    </head>
+    <body>
+    </body>
+</html>

--- a/tests/data/publishdate/test_publish_date_config.json
+++ b/tests/data/publishdate/test_publish_date_config.json
@@ -1,0 +1,6 @@
+{
+    "url": "http://example.com/test_publish_date_config.html",
+    "expected": {
+        "publish_date": "2014-11-23T15:00:00+04:00"
+    }
+}

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 
 from .test_base import TestExtractionBase
 
+from goose3 import ArticleContextPattern
 from goose3.text import StopWordsChinese
 from goose3.text import StopWordsArabic
 from goose3.text import StopWordsKorean
@@ -235,6 +236,33 @@ class TestExtractions(TestExtractionBase):
         # https://github.com/grangier/python-goose/issues/115
         article = self.getArticle()
         fields = ['cleaned_text']
+        self.runArticleAssertions(article=article, fields=fields)
+
+    def test_pattern_config(self):
+        fields = ['cleaned_text']
+        # Test with configuring the content pattern with a dict and no domain filter
+        config0 = {'known_context_patterns': {'attr': 'class', 'value': 'super-rare-article-tag'}}
+        article = self.getArticle(config_=config0)
+        self.runArticleAssertions(article=article, fields=fields)
+
+        # Test with configuring the pubdate with a PublishDatePattern and no domain filter
+        config1 = {'known_context_patterns': ArticleContextPattern(attr='class',
+                                                                   value='super-rare-article-tag')}
+        article = self.getArticle(config_=config1)
+        self.runArticleAssertions(article=article, fields=fields)
+
+        # Test with configuring the incorrect domain filter
+        config2 = {'known_context_patterns': ArticleContextPattern(attr='class',
+                                                                   value='super-rare-article-tag',
+                                                                   domain='incorrect.com')}
+        article = self.getArticle(config_=config2)
+        assert article.cleaned_text == "This should not be included."
+
+        # Test with configuring the correct domain filter
+        config3 = {'known_context_patterns': ArticleContextPattern(attr='class',
+                                                                   value='super-rare-article-tag',
+                                                                   domain='example.com')}
+        article = self.getArticle(config_=config3)
         self.runArticleAssertions(article=article, fields=fields)
 
 

--- a/tests/test_publishdate.py
+++ b/tests/test_publishdate.py
@@ -23,6 +23,8 @@ limitations under the License.
 
 from __future__ import absolute_import
 
+from goose3 import Configuration, PublishDatePattern
+
 from .test_base import TestExtractionBase
 
 
@@ -42,4 +44,34 @@ class TestPublishDate(TestExtractionBase):
 
     def test_publish_date_schema(self):
         article = self.getArticle()
+        self.runArticleAssertions(article=article, fields=['publish_date'])
+
+    def test_publish_date_config(self):
+        # Test with configuring the pubdate with a dict and no domain filter
+        config0 = {'known_publish_date_tags': {'attribute': 'name', 'value': 'super-rare-date-tag',
+                                               'content': 'value'}}
+        article = self.getArticle(config_=config0)
+        self.runArticleAssertions(article=article, fields=['publish_date'])
+
+        # Test with configuring the pubdate with a PublishDatePattern and no domain filter
+        config1 = {'known_publish_date_tags': PublishDatePattern(attr='name',
+                                                                 value='super-rare-date-tag',
+                                                                 content='value')}
+        article = self.getArticle(config_=config1)
+        self.runArticleAssertions(article=article, fields=['publish_date'])
+
+        # Test with configuring the incorrect domain filter
+        config2 = {'known_publish_date_tags': PublishDatePattern(attr='name',
+                                                                 value='super-rare-date-tag',
+                                                                 content='value',
+                                                                 domain='incorrect.com')}
+        article = self.getArticle(config_=config2)
+        assert not article.publish_date
+
+        # Test with configuring the correct domain filter
+        config3 = {'known_publish_date_tags': PublishDatePattern(attr='name',
+                                                                 value='super-rare-date-tag',
+                                                                 content='value',
+                                                                 domain='example.com')}
+        article = self.getArticle(config_=config3)
         self.runArticleAssertions(article=article, fields=['publish_date'])


### PR DESCRIPTION
## Summary

 - Loosely enforce PEP 8
 - Use a class instead of a `dict` for the article context and publish date patterns
 - Move the static `KNOWN_PUBLISH_DATE_TAGS` list to the `Configuration` class
with a property and setter function allowing users to configure custom
tags for lesser used publish_date tags.

## Example

```python
import warnings
from goose3 import Goose, Configuration, PublishDatePattern

warnings.simplefilter('always', DeprecationWarning)

config = Configuration()

config.known_publish_date_tags = {'attribute': 'name', 'value': 'pubdate', 'content': 'content',
                                  'domain': 'sputniknews.com'}
# or
config.known_publish_date_tags = PublishDatePattern(attr='name', value='pubdate', content='content',
                                                    domain='sputniknews.com')

g = Goose(config)
article = g.extract(url="https://sputniknews.com/middleeast/201807281066762466-syrian-kurds-government-agreement/")

print(article.publish_date)                                                                                                                                                                                                           
```