### PR TITLE
Fix IndexError in title extraction

### DIFF
--- a/goose3/extractors/title.py
+++ b/goose3/extractors/title.py
@@ -51,15 +51,15 @@ class TitleExtractor(BaseExtractor):
         # my wonderfull article | TechCrunch
         title_words = title.split()
 
-        # check for an empty title
-        # so that we don't get an IndexError below
-        if len(title_words) == 0:
-            return ""
-
         # check if first letter is in TITLE_SPLITTERS
         # if so remove it
-        if title_words[0] in TITLE_SPLITTERS:
+        if title_words and title_words[0] in TITLE_SPLITTERS:
             title_words.pop(0)
+
+        # check for a title that is empty or consists of only a
+        # title splitter to avoid a IndexError below
+        if not title_words:
+            return ""
 
         # check if last letter is in TITLE_SPLITTERS
         # if so remove it

--- a/tests/data/title/test_title_splitter.html
+++ b/tests/data/title/test_title_splitter.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <meta property="og:site_name" content="Some Title"/>
+        <title> | Some Title</title>
+    </head>
+    <body>
+        A title containing only a splitter and the site name is the same as an empty title
+    </body>
+</html>

--- a/tests/data/title/test_title_splitter.json
+++ b/tests/data/title/test_title_splitter.json
@@ -1,0 +1,6 @@
+{
+    "url": "http://exemple.com/test_title_splitter.html",
+    "expected": {
+        "title": ""
+    }
+}

--- a/tests/test_title.py
+++ b/tests/test_title.py
@@ -37,3 +37,8 @@ class TestTitle(TestExtractionBase):
         article = self.getArticle()
         fields = ['title']
         self.runArticleAssertions(article=article, fields=fields)
+
+    def test_title_splitter(self):
+        article = self.getArticle()
+        fields = ['title']
+        self.runArticleAssertions(article=article, fields=fields)


### PR DESCRIPTION
If the title consists of only the open graph site name and a splitter,
an `IndexError` is hit in `clean_title`.

Fixes: #59