### PR TITLE
Retry calculate_top_node with root node

### DIFF
--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -165,16 +165,25 @@ class Crawler(object):
         # this will prevent the cleaner to remove unwanted text content
         article_body = self.extractor.get_known_article_tags()
         if article_body is not None:
-            self.article._doc = article_body
+            doc = article_body
 
         # before we do any calcs on the body itself let's clean up the document
-        if not isinstance(self.article.doc, list):
-            self.article._doc = [self.cleaner.clean(self.article.doc)]
+        if not isinstance(doc, list):
+            doc = [self.cleaner.clean(doc)]
         else:
-            self.article._doc = [self.cleaner.clean(deepcopy(x)) for x in self.article.doc]
+            doc = [self.cleaner.clean(deepcopy(x)) for x in doc]
 
         # big stuff
-        self.article._top_node = self.extractor.calculate_best_node()
+        self.article._top_node = self.extractor.calculate_best_node(doc)
+
+        # if we do not find an article within the discovered possible article nodes,
+        # try again with the root node.
+        if self.article._top_node is None:
+            # try again with the root node.
+            self.article._top_node = self.extractor.calculate_best_node(self.article._doc)
+        else:
+            # set the doc member to the discovered article node.
+            self.article._doc = doc
 
         # if we have a top node
         # let's process it

--- a/goose3/extractors/content.py
+++ b/goose3/extractors/content.py
@@ -74,9 +74,7 @@ class ContentExtractor(BaseExtractor):
 
         return False
 
-    def calculate_best_node(self):
-
-        doc = self.article.doc
+    def calculate_best_node(self, doc):
         top_node = None
         nodes_to_check = self.nodes_to_check(doc)
 

--- a/tests/data/content/test_retry_top_node.html
+++ b/tests/data/content/test_retry_top_node.html
@@ -1,0 +1,26 @@
+<html>
+  <body>
+    <div>
+      <div class="articleBody">
+        <script>
+          console.log("These are known article tags.")
+        </script>
+      </div>
+      <article>
+        <script>
+          console.log("None of them contain content.")
+        </script>
+      </article>
+      <div class="short-story">
+        <script>
+          console.log("As a result, we miss the real article.")
+        </script>
+      </div>
+    </div>
+    <div>
+      <p>
+        This is the <b>real</b> article!
+      </p>
+    </div>
+  </body>
+</html>

--- a/tests/data/content/test_retry_top_node.json
+++ b/tests/data/content/test_retry_top_node.json
@@ -1,0 +1,6 @@
+{
+    "url": "http://example.com/test_retry_top_node.html",
+    "expected": {
+        "cleaned_text": "This is the real article!"
+    }
+}

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -265,6 +265,10 @@ class TestExtractions(TestExtractionBase):
         article = self.getArticle(config_=config3)
         self.runArticleAssertions(article=article, fields=fields)
 
+    def test_retry_top_node(self):
+        article = self.getArticle()
+        self.runArticleAssertions(article=article, fields=["cleaned_text"])
+
 
 class TestArticleTopNode(TestExtractionBase):
 


### PR DESCRIPTION
## Summary

Retry the `calculate_top_node` function with the root node if the first
pass failed to find an article. This may occur if one or more known
article patterns are found, but none contain content.

## A real life example

```python
from goose3 import Goose
g = Goose()
article = g.extract(url="http://time.com/5344247/mars-2020-rover-name-contest/")
article.cleaned_text
''
```

See the added test for a more clear cut example.