### PR TITLE
publish_datetime property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Goose3
 
-### Version 3.1.4
-* Fix IndexError when title has only an title splitter or is the site name [see issue #59](https://github.com/goose3/goose3/issues/48) Thanks [@dlrobertson](https://github.com/dlrobertson)!
-* Retry the calculate_top_node function with the root node if the first pass failed to find an article which may occur if one or more known article patterns are found, but none contain content [see PR #66](https://github.com/goose3/goose3/issues/48) Thanks [@dlrobertson](https://github.com/dlrobertson)!
-* Add parsing of schema.org's ReportageNewsArticle tags [see PR #67](https://github.com/goose3/goose3/issues/48) Thanks [@dlrobertson](https://github.com/dlrobertson)!
-* Add additional parsing of opengraph tags [see PR #64](https://github.com/goose3/goose3/issues/48) Thanks [@dlrobertson](https://github.com/dlrobertson)!
+### Current Version
+* Added additional date parsing [see PR #71](https://github.com/goose3/goose3/pull/71) Thanks [@dlrobertson](https://github.com/dlrobertson)!
+* Added datetime representation of the publish date `publish_datetime_utc` [see issue #72](https://github.com/goose3/goose3/issues/72)
 
+### Version 3.1.4
+* Fix IndexError when title has only an title splitter or is the site name [see issue #59](https://github.com/goose3/goose3/issues/59) Thanks [@dlrobertson](https://github.com/dlrobertson)!
+* Retry the calculate_top_node function with the root node if the first pass failed to find an article which may occur if one or more known article patterns are found, but none contain content [see PR #66](https://github.com/goose3/goose3/pull/66) Thanks [@dlrobertson](https://github.com/dlrobertson)!
+* Add parsing of schema.org's ReportageNewsArticle tags [see PR #67](https://github.com/goose3/goose3/pull/67) Thanks [@dlrobertson](https://github.com/dlrobertson)!
+* Add additional parsing of opengraph tags [see PR #64](https://github.com/goose3/goose3/pull/64) Thanks [@dlrobertson](https://github.com/dlrobertson)!
 
 ### Version 3.1.3
 * Parse headers and include in `cleaned_text`
@@ -24,13 +27,13 @@
 
 ### Version 3.1.0
 * Changed configuration to ***not*** pull images by default [see issue #31](https://github.com/goose3/goose3/issues/31)
-* Update `get_encodings_from_content` to return a string and remove trailing spaces [#35](https://github.com/goose3/goose3/pull/35)
-* Remove infinite recursion on parser selection [#39](https://github.com/goose3/goose3/pull/39)
+* Update `get_encodings_from_content` to return a string and remove trailing spaces [see PR #35](https://github.com/goose3/goose3/pull/35)
+* Remove infinite recursion on parser selection [see PR #39](https://github.com/goose3/goose3/pull/39)
 * Document video and image classes
 * Re-add remaining image tests
 
 ### Version 3.0.9
-* Add `soup` as a parser option to use `lxml.html.soupparser` [#27](https://github.com/goose3/goose3/issues/27)
+* Add `soup` as a parser option to use `lxml.html.soupparser` [see issue #27](https://github.com/goose3/goose3/issues/27)
 * Fix an issue with passing the requests session object to the crawler
 * Pylint changes
     * Added pylintrc file
@@ -55,17 +58,17 @@ the connection on garbage collection
     * Added http_headers configuration option to be passed to `requests`
     * Added http_proxies configuration option to be passed to `requests`
     * Added http_auth configuration option to be passed to `requests`
-* Fix base64 image parsing [#7](https://github.com/goose3/goose3/issues/7)
+* Fix base64 image parsing [see issue #7](https://github.com/goose3/goose3/issues/7)
 
 ### Version 3.0.7
 * Fix installation issue
     * Removed unused/broken regex
     * Include all necessary files
     * Fix failed tests (**most**)
-* Resolved relative URL issue [#21](https://github.com/goose3/goose3/issues/21)
-* Resolved temporary files not being properly removed [#18](https://github.com/goose3/goose3/issues/18)
-* Removed unused dependencies and code to support python 2 [#16](https://github.com/goose3/goose3/issues/16)
-* Fix error when using the configuration object to configure goose [#14](https://github.com/goose3/goose3/issues/14)
+* Resolved relative URL issue [see issue #21](https://github.com/goose3/goose3/issues/21)
+* Resolved temporary files not being properly removed [see issue #18](https://github.com/goose3/goose3/issues/18)
+* Removed unused dependencies and code to support python 2 [see issue #16](https://github.com/goose3/goose3/issues/16)
+* Fix error when using the configuration object to configure goose [see issue #14](https://github.com/goose3/goose3/issues/14)
 
 ### Version 3.0.1
 * First working version of Goose3!

--- a/goose3/article.py
+++ b/goose3/article.py
@@ -50,6 +50,7 @@ class Article(object):
         self._raw_doc = None
         self._publish_date = None
         self._publish_datetime = None
+        self._publish_utc = None
         self._additional_data = {}
 
     @property
@@ -257,6 +258,15 @@ class Article(object):
             Note:
                 Read only '''
         return self._publish_datetime
+
+    @property
+    def publish_utc(self):
+        ''' datetime.datetime: The date time version of the published date based on meta tag extraction \
+            in the UTC timezone, if timezone information is known
+
+            Note:
+                Read only '''
+        return self._publish_utc
 
     @property
     def additional_data(self):

--- a/goose3/article.py
+++ b/goose3/article.py
@@ -49,8 +49,7 @@ class Article(object):
         self._doc = None
         self._raw_doc = None
         self._publish_date = None
-        self._publish_datetime = None
-        self._publish_utc = None
+        self._publish_datetime_utc = None
         self._additional_data = {}
 
     @property
@@ -252,21 +251,13 @@ class Article(object):
         return self._publish_date
 
     @property
-    def publish_datetime(self):
-        ''' datetime.datetime: The date time version of the published date based on meta tag extraction
-
-            Note:
-                Read only '''
-        return self._publish_datetime
-
-    @property
-    def publish_utc(self):
+    def publish_datetime_utc(self):
         ''' datetime.datetime: The date time version of the published date based on meta tag extraction \
             in the UTC timezone, if timezone information is known
 
             Note:
                 Read only '''
-        return self._publish_utc
+        return self._publish_datetime_utc
 
     @property
     def additional_data(self):

--- a/goose3/article.py
+++ b/goose3/article.py
@@ -49,6 +49,7 @@ class Article(object):
         self._doc = None
         self._raw_doc = None
         self._publish_date = None
+        self._publish_datetime = None
         self._additional_data = {}
 
     @property
@@ -248,6 +249,14 @@ class Article(object):
             Note:
                 Read only '''
         return self._publish_date
+
+    @property
+    def publish_datetime(self):
+        ''' datetime.datetime: The date time version of the published date based on meta tag extraction
+
+            Note:
+                Read only '''
+        return self._publish_datetime
 
     @property
     def additional_data(self):

--- a/goose3/configuration.py
+++ b/goose3/configuration.py
@@ -53,7 +53,8 @@ KNOWN_ARTICLE_CONTENT_PATTERNS = [
     ArticleContextPattern(attr='itemprop', value='articleBody'),
     ArticleContextPattern(attr='class', value='post-content'),
     ArticleContextPattern(attr='class', value='g-content'),
-    ArticleContextPattern(tag='article')
+    ArticleContextPattern(attr='class', value='post-outer'),
+    ArticleContextPattern(tag='article'),
 ]
 
 
@@ -86,7 +87,7 @@ KNOWN_PUBLISH_DATE_TAGS = [
     PublishDatePattern(attr='itemprop', value='datePublished', content='datetime'),
     PublishDatePattern(attr='name', value='published_time_telegram', content='content'),
     PublishDatePattern(attr='name', value='parsely-page', content='content', subcontent='pub_date'),
-    PublishDatePattern(tag='time')
+    PublishDatePattern(tag='time'),
 ]
 
 

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -169,13 +169,13 @@ class Crawler(object):
         self.article._publish_date = self.publishdate_extractor.extract()
         if self.article.publish_date:
             try:
-                self.article._publish_datetime = dateutil.parser.parse(self.article.publish_date)
-                if self.article.publish_datetime.tzinfo:
-                    self.article._publish_utc = self.article._publish_datetime.astimezone(tzutc())
+                publish_datetime = dateutil.parser.parse(self.article.publish_date)
+                if publish_datetime.tzinfo:
+                    self.article._publish_datetime_utc = publish_datetime.astimezone(tzutc())
                 else:
-                    self.article._publish_utc = self.article.publish_datetime
+                    self.article._publish_datetime_utc = publish_datetime
             except (ValueError, OverflowError):
-                self.article._publish_datetime = None
+                self.article._publish_datetime_utc = None
 
         # tags
         self.article._tags = self.tags_extractor.extract()

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -24,6 +24,8 @@ import os
 import glob
 from copy import deepcopy
 
+import dateutil.parser
+
 from goose3.article import Article
 from goose3.utils import URLHelper, RawHelper
 from goose3.extractors.content import StandardContentExtractor
@@ -164,6 +166,11 @@ class Crawler(object):
 
         # publishdate
         self.article._publish_date = self.publishdate_extractor.extract()
+        if self.article.publish_date:
+            try:
+                self.article._publish_datetime = dateutil.parser.parse(self.article.publish_date)
+            except (ValueError, OverflowError):
+                self.article._publish_datetime = None
 
         # tags
         self.article._tags = self.tags_extractor.extract()

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -25,6 +25,7 @@ import glob
 from copy import deepcopy
 
 import dateutil.parser
+from dateutil.tz import tzutc
 
 from goose3.article import Article
 from goose3.utils import URLHelper, RawHelper
@@ -169,6 +170,10 @@ class Crawler(object):
         if self.article.publish_date:
             try:
                 self.article._publish_datetime = dateutil.parser.parse(self.article.publish_date)
+                if self.article.publish_datetime.tzinfo:
+                    self.article._publish_utc = self.article._publish_datetime.astimezone(tzutc())
+                else:
+                    self.article._publish_utc = self.article.publish_datetime
             except (ValueError, OverflowError):
                 self.article._publish_datetime = None
 

--- a/goose3/extractors/content.py
+++ b/goose3/extractors/content.py
@@ -374,8 +374,8 @@ class ContentExtractor(BaseExtractor):
         for elm in self.parser.getChildren(node):
             e_tag = self.parser.getTag(elm)
             if e_tag not in parse_tags:
-                if (self.is_highlink_density(elm) or self.is_table_and_no_para_exist(elm)
-                        or not self.is_nodescore_threshold_met(node, elm)):
+                if (self.is_highlink_density(elm) or self.is_table_and_no_para_exist(elm) or
+                        not self.is_nodescore_threshold_met(node, elm)):
                     self.parser.remove(elm)
         return node
 

--- a/goose3/outputformatters.py
+++ b/goose3/outputformatters.py
@@ -141,9 +141,9 @@ class OutputFormatter(object):
             tag = self.parser.getTag(elm)
             text = self.parser.getText(elm)
             stop_words = self.stopwords_class(language=self.get_language()).get_stopword_count(text)
-            if ((tag != 'br' or text != '\\r') and stop_words.get_stopword_count() < 3
-                    and len(self.parser.getElementsByTag(elm, tag='object')) == 0
-                    and len(self.parser.getElementsByTag(elm, tag='embed')) == 0):
+            if ((tag != 'br' or text != '\\r') and stop_words.get_stopword_count() < 3 and
+                    len(self.parser.getElementsByTag(elm, tag='object')) == 0 and
+                    len(self.parser.getElementsByTag(elm, tag='embed')) == 0):
                 self.parser.remove(elm)
             # TODO
             # check if it is in the right place

--- a/requirements/python
+++ b/requirements/python
@@ -5,3 +5,4 @@ cssselect
 jieba
 beautifulsoup4
 nltk
+python-dateutil

--- a/tests/data/publishdate/test_publish_date.json
+++ b/tests/data/publishdate/test_publish_date.json
@@ -1,6 +1,7 @@
 {
   "url": "http://example.com/example",
     "expected": {
-        "publish_date": "2014-06-30T16:54:02+00:00"
+        "publish_date": "2014-06-30T16:54:02+00:00",
+        "publish_datetime": "2014-06-30 16:54:02+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date.json
+++ b/tests/data/publishdate/test_publish_date.json
@@ -2,6 +2,7 @@
   "url": "http://example.com/example",
     "expected": {
         "publish_date": "2014-06-30T16:54:02+00:00",
-        "publish_datetime": "2014-06-30 16:54:02+00:00"
+        "publish_datetime": "2014-06-30 16:54:02+00:00",
+        "publish_utc": "2014-06-30 16:54:02+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date.json
+++ b/tests/data/publishdate/test_publish_date.json
@@ -2,7 +2,6 @@
   "url": "http://example.com/example",
     "expected": {
         "publish_date": "2014-06-30T16:54:02+00:00",
-        "publish_datetime": "2014-06-30 16:54:02+00:00",
-        "publish_utc": "2014-06-30 16:54:02+00:00"
+        "publish_datetime_utc": "2014-06-30 16:54:02+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_article.json
+++ b/tests/data/publishdate/test_publish_date_article.json
@@ -2,6 +2,7 @@
   "url": "http://example.com/example",
     "expected": {
         "publish_date": "2012-01-11T15:55:01+00:00",
-        "publish_datetime": "2012-01-11 15:55:01+00:00"
+        "publish_datetime": "2012-01-11 15:55:01+00:00",
+        "publish_utc": "2012-01-11 15:55:01+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_article.json
+++ b/tests/data/publishdate/test_publish_date_article.json
@@ -2,7 +2,6 @@
   "url": "http://example.com/example",
     "expected": {
         "publish_date": "2012-01-11T15:55:01+00:00",
-        "publish_datetime": "2012-01-11 15:55:01+00:00",
-        "publish_utc": "2012-01-11 15:55:01+00:00"
+        "publish_datetime_utc": "2012-01-11 15:55:01+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_article.json
+++ b/tests/data/publishdate/test_publish_date_article.json
@@ -1,6 +1,7 @@
 {
   "url": "http://example.com/example",
     "expected": {
-        "publish_date": "2012-01-11T15:55:01+00:00"
+        "publish_date": "2012-01-11T15:55:01+00:00",
+        "publish_datetime": "2012-01-11 15:55:01+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_config.json
+++ b/tests/data/publishdate/test_publish_date_config.json
@@ -1,6 +1,7 @@
 {
     "url": "http://example.com/test_publish_date_config.html",
     "expected": {
-        "publish_date": "2014-11-23T15:00:00+04:00"
+        "publish_date": "2014-11-23T15:00:00+04:00",
+        "publish_datetime": "2014-11-23 15:00:00+04:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_config.json
+++ b/tests/data/publishdate/test_publish_date_config.json
@@ -2,7 +2,6 @@
     "url": "http://example.com/test_publish_date_config.html",
     "expected": {
         "publish_date": "2014-11-23T15:00:00+04:00",
-        "publish_datetime": "2014-11-23 15:00:00+04:00",
-        "publish_utc": "2014-11-23 11:00:00+00:00"
+        "publish_datetime_utc": "2014-11-23 11:00:00+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_config.json
+++ b/tests/data/publishdate/test_publish_date_config.json
@@ -2,6 +2,7 @@
     "url": "http://example.com/test_publish_date_config.html",
     "expected": {
         "publish_date": "2014-11-23T15:00:00+04:00",
-        "publish_datetime": "2014-11-23 15:00:00+04:00"
+        "publish_datetime": "2014-11-23 15:00:00+04:00",
+        "publish_utc": "2014-11-23 11:00:00+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_parsely_page.json
+++ b/tests/data/publishdate/test_publish_date_parsely_page.json
@@ -2,7 +2,6 @@
   "url": "http://example.com/test_publish_date_parsely_page.html",
   "expected": {
       "publish_date": "2014-11-23T16:00:00+04:00",
-      "publish_datetime": "2014-11-23 16:00:00+04:00",
-      "publish_utc": "2014-11-23 12:00:00+00:00"
+      "publish_datetime_utc": "2014-11-23 12:00:00+00:00"
   }
 }

--- a/tests/data/publishdate/test_publish_date_parsely_page.json
+++ b/tests/data/publishdate/test_publish_date_parsely_page.json
@@ -1,6 +1,7 @@
 {
   "url": "http://example.com/test_publish_date_parsely_page.html",
   "expected": {
-      "publish_date": "2014-11-23T16:00:00+04:00"
+      "publish_date": "2014-11-23T16:00:00+04:00",
+      "publish_datetime": "2014-11-23 16:00:00+04:00"
   }
 }

--- a/tests/data/publishdate/test_publish_date_parsely_page.json
+++ b/tests/data/publishdate/test_publish_date_parsely_page.json
@@ -2,6 +2,7 @@
   "url": "http://example.com/test_publish_date_parsely_page.html",
   "expected": {
       "publish_date": "2014-11-23T16:00:00+04:00",
-      "publish_datetime": "2014-11-23 16:00:00+04:00"
+      "publish_datetime": "2014-11-23 16:00:00+04:00",
+      "publish_utc": "2014-11-23 12:00:00+00:00"
   }
 }

--- a/tests/data/publishdate/test_publish_date_rnews.json
+++ b/tests/data/publishdate/test_publish_date_rnews.json
@@ -2,6 +2,7 @@
     "url": "http://example.com/example",
     "expected": {
         "publish_date": "2010-02-22T11:53:04+00:00",
-        "publish_datetime": "2010-02-22 11:53:04+00:00"
+        "publish_datetime": "2010-02-22 11:53:04+00:00",
+        "publish_utc": "2010-02-22 11:53:04+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_rnews.json
+++ b/tests/data/publishdate/test_publish_date_rnews.json
@@ -2,7 +2,6 @@
     "url": "http://example.com/example",
     "expected": {
         "publish_date": "2010-02-22T11:53:04+00:00",
-        "publish_datetime": "2010-02-22 11:53:04+00:00",
-        "publish_utc": "2010-02-22 11:53:04+00:00"
+        "publish_datetime_utc": "2010-02-22 11:53:04+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_rnews.json
+++ b/tests/data/publishdate/test_publish_date_rnews.json
@@ -1,6 +1,7 @@
 {
     "url": "http://example.com/example",
     "expected": {
-        "publish_date": "2010-02-22T11:53:04+00:00"
+        "publish_date": "2010-02-22T11:53:04+00:00",
+        "publish_datetime": "2010-02-22 11:53:04+00:00"
     }
 }

--- a/tests/data/publishdate/test_publish_date_schema.json
+++ b/tests/data/publishdate/test_publish_date_schema.json
@@ -1,6 +1,7 @@
 {
     "url": "http://example.com/example",
     "expected": {
-        "publish_date": "2014-10-09T12:06:16"
+        "publish_date": "2014-10-09T12:06:16",
+        "publish_datetime": "2014-10-09 12:06:16"
     }
 }

--- a/tests/data/publishdate/test_publish_date_schema.json
+++ b/tests/data/publishdate/test_publish_date_schema.json
@@ -2,7 +2,6 @@
     "url": "http://example.com/example",
     "expected": {
         "publish_date": "2014-10-09T12:06:16",
-        "publish_datetime": "2014-10-09 12:06:16",
-        "publish_utc": "2014-10-09 12:06:16"
+        "publish_datetime_utc": "2014-10-09 12:06:16"
     }
 }

--- a/tests/data/publishdate/test_publish_date_schema.json
+++ b/tests/data/publishdate/test_publish_date_schema.json
@@ -2,6 +2,7 @@
     "url": "http://example.com/example",
     "expected": {
         "publish_date": "2014-10-09T12:06:16",
-        "publish_datetime": "2014-10-09 12:06:16"
+        "publish_datetime": "2014-10-09 12:06:16",
+        "publish_utc": "2014-10-09 12:06:16"
     }
 }

--- a/tests/data/publishdate/test_publish_date_tag.json
+++ b/tests/data/publishdate/test_publish_date_tag.json
@@ -2,6 +2,7 @@
   "url": "http://example.com/test_publish_date_tag.html",
   "expected": {
       "publish_date": "2014-11-23T16:00:00+04:00",
-      "publish_datetime": "2014-11-23 16:00:00+04:00"
+      "publish_datetime": "2014-11-23 16:00:00+04:00",
+      "publish_utc": "2014-11-23 12:00:00+00:00"
   }
 }

--- a/tests/data/publishdate/test_publish_date_tag.json
+++ b/tests/data/publishdate/test_publish_date_tag.json
@@ -2,7 +2,6 @@
   "url": "http://example.com/test_publish_date_tag.html",
   "expected": {
       "publish_date": "2014-11-23T16:00:00+04:00",
-      "publish_datetime": "2014-11-23 16:00:00+04:00",
-      "publish_utc": "2014-11-23 12:00:00+00:00"
+      "publish_datetime_utc": "2014-11-23 12:00:00+00:00"
   }
 }

--- a/tests/data/publishdate/test_publish_date_tag.json
+++ b/tests/data/publishdate/test_publish_date_tag.json
@@ -1,6 +1,7 @@
 {
   "url": "http://example.com/test_publish_date_tag.html",
   "expected": {
-      "publish_date": "2014-11-23T16:00:00+04:00"
+      "publish_date": "2014-11-23T16:00:00+04:00",
+      "publish_datetime": "2014-11-23 16:00:00+04:00"
   }
 }

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -21,6 +21,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import json
+from datetime import datetime
 import os
 import unittest
 
@@ -110,6 +111,11 @@ class TestExtractionBase(unittest.TestCase):
             expected_value = self.data['expected'][field]
             result_value = getattr(article, field, None)
 
+            # handle checking datetimes...
+            if field == 'publish_datetime':
+                self.assertEqual(type(result_value), type(datetime.today()))
+                result_value = result_value.isoformat(sep=' ')
+
             # custom assertion for a given field
             assertion = 'assert_%s' % field
             if hasattr(self, assertion):
@@ -117,7 +123,7 @@ class TestExtractionBase(unittest.TestCase):
                 continue
 
             # default assertion
-            msg = "Error %s \nexpected: %s\nresult: %s" % (field, expected_value, result_value)
+            msg = "Error %s \nexpected: %s\nresult:   %s" % (field, expected_value, result_value)
             self.assertEqual(expected_value, result_value, msg=msg)
 
     # def extract(self, instance):
@@ -181,4 +187,3 @@ class TestExtractionBase(unittest.TestCase):
                 return g.extract(url=self.data['url'])
             else:
                 return g.extract(raw_html=self.html)
-

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -112,7 +112,7 @@ class TestExtractionBase(unittest.TestCase):
             result_value = getattr(article, field, None)
 
             # handle checking datetimes...
-            if field in ['publish_datetime', 'publish_utc']:
+            if field in ['publish_datetime_utc']:
                 self.assertEqual(type(result_value), type(datetime.today()))
                 result_value = result_value.isoformat(sep=' ')
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -112,7 +112,7 @@ class TestExtractionBase(unittest.TestCase):
             result_value = getattr(article, field, None)
 
             # handle checking datetimes...
-            if field == 'publish_datetime':
+            if field in ['publish_datetime', 'publish_utc']:
                 self.assertEqual(type(result_value), type(datetime.today()))
                 result_value = result_value.isoformat(sep=' ')
 

--- a/tests/test_publishdate.py
+++ b/tests/test_publishdate.py
@@ -32,43 +32,43 @@ class TestPublishDate(TestExtractionBase):
 
     def test_publish_date(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
     def test_publish_date_rnews(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
     def test_publish_date_article(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
     def test_publish_date_schema(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
     def test_publish_date_parsely_page(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
     def test_publish_date_tag(self):
         config = {'known_publish_date_tags': {'attribute': 'class', 'value': 'pubdate',
                                               'tag': 'div'}}
         article = self.getArticle(config)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
     def test_publish_date_config(self):
         # Test with configuring the pubdate with a dict and no domain filter
         config0 = {'known_publish_date_tags': {'attribute': 'name', 'value': 'super-rare-date-tag',
                                                'content': 'value'}}
         article = self.getArticle(config_=config0)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
         # Test with configuring the pubdate with a PublishDatePattern and no domain filter
         config1 = {'known_publish_date_tags': PublishDatePattern(attr='name',
                                                                  value='super-rare-date-tag',
                                                                  content='value')}
         article = self.getArticle(config_=config1)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
 
         # Test with configuring the incorrect domain filter
         config2 = {'known_publish_date_tags': PublishDatePattern(attr='name',
@@ -78,6 +78,7 @@ class TestPublishDate(TestExtractionBase):
         article = self.getArticle(config_=config2)
         assert not article.publish_date
         assert not article.publish_datetime
+        assert not article.publish_utc
 
         # Test with configuring the correct domain filter
         config3 = {'known_publish_date_tags': PublishDatePattern(attr='name',
@@ -85,4 +86,4 @@ class TestPublishDate(TestExtractionBase):
                                                                  content='value',
                                                                  domain='example.com')}
         article = self.getArticle(config_=config3)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])

--- a/tests/test_publishdate.py
+++ b/tests/test_publishdate.py
@@ -32,43 +32,43 @@ class TestPublishDate(TestExtractionBase):
 
     def test_publish_date(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
     def test_publish_date_rnews(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
     def test_publish_date_article(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
     def test_publish_date_schema(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
     def test_publish_date_parsely_page(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
     def test_publish_date_tag(self):
         config = {'known_publish_date_tags': {'attribute': 'class', 'value': 'pubdate',
                                               'tag': 'div'}}
         article = self.getArticle(config)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
     def test_publish_date_config(self):
         # Test with configuring the pubdate with a dict and no domain filter
         config0 = {'known_publish_date_tags': {'attribute': 'name', 'value': 'super-rare-date-tag',
                                                'content': 'value'}}
         article = self.getArticle(config_=config0)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
         # Test with configuring the pubdate with a PublishDatePattern and no domain filter
         config1 = {'known_publish_date_tags': PublishDatePattern(attr='name',
                                                                  value='super-rare-date-tag',
                                                                  content='value')}
         article = self.getArticle(config_=config1)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])
 
         # Test with configuring the incorrect domain filter
         config2 = {'known_publish_date_tags': PublishDatePattern(attr='name',
@@ -77,8 +77,7 @@ class TestPublishDate(TestExtractionBase):
                                                                  domain='incorrect.com')}
         article = self.getArticle(config_=config2)
         assert not article.publish_date
-        assert not article.publish_datetime
-        assert not article.publish_utc
+        assert not article.publish_datetime_utc
 
         # Test with configuring the correct domain filter
         config3 = {'known_publish_date_tags': PublishDatePattern(attr='name',
@@ -86,4 +85,4 @@ class TestPublishDate(TestExtractionBase):
                                                                  content='value',
                                                                  domain='example.com')}
         article = self.getArticle(config_=config3)
-        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime', 'publish_utc'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime_utc'])

--- a/tests/test_publishdate.py
+++ b/tests/test_publishdate.py
@@ -32,43 +32,43 @@ class TestPublishDate(TestExtractionBase):
 
     def test_publish_date(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
     def test_publish_date_rnews(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
     def test_publish_date_article(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
     def test_publish_date_schema(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
     def test_publish_date_parsely_page(self):
         article = self.getArticle()
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
     def test_publish_date_tag(self):
         config = {'known_publish_date_tags': {'attribute': 'class', 'value': 'pubdate',
                                               'tag': 'div'}}
         article = self.getArticle(config)
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
     def test_publish_date_config(self):
         # Test with configuring the pubdate with a dict and no domain filter
         config0 = {'known_publish_date_tags': {'attribute': 'name', 'value': 'super-rare-date-tag',
                                                'content': 'value'}}
         article = self.getArticle(config_=config0)
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
         # Test with configuring the pubdate with a PublishDatePattern and no domain filter
         config1 = {'known_publish_date_tags': PublishDatePattern(attr='name',
                                                                  value='super-rare-date-tag',
                                                                  content='value')}
         article = self.getArticle(config_=config1)
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])
 
         # Test with configuring the incorrect domain filter
         config2 = {'known_publish_date_tags': PublishDatePattern(attr='name',
@@ -77,6 +77,7 @@ class TestPublishDate(TestExtractionBase):
                                                                  domain='incorrect.com')}
         article = self.getArticle(config_=config2)
         assert not article.publish_date
+        assert not article.publish_datetime
 
         # Test with configuring the correct domain filter
         config3 = {'known_publish_date_tags': PublishDatePattern(attr='name',
@@ -84,4 +85,4 @@ class TestPublishDate(TestExtractionBase):
                                                                  content='value',
                                                                  domain='example.com')}
         article = self.getArticle(config_=config3)
-        self.runArticleAssertions(article=article, fields=['publish_date'])
+        self.runArticleAssertions(article=article, fields=['publish_date', 'publish_datetime'])


### PR DESCRIPTION
* add a `publish_datetime` property that is the datetime object of the `publish_date` string
   * required adding a new external library: `python-dateutils`
   * results is **None** if an exception occurs in parsing to datetime
* added the blogger extraction point to known context patterns

resolves: #72 