### PR TITLE
Handle og_type lists with NoneTypes

### DIFF
--- a/goose3/extractors/opengraph.py
+++ b/goose3/extractors/opengraph.py
@@ -40,7 +40,8 @@ class OpenGraphExtractor(BaseExtractor):
             for meta in metas
             if self.parser.getAttribute(meta, 'property') == "og:type"
         ]
-        if og_types:
+        
+        if og_types[0]:
             og_type = og_types[0] + ":"
 
         for meta in metas:


### PR DESCRIPTION
Since only the first type is being considered anyway, it makes sense to handle lists with `NoneType` objects by checking only that element.

In the future, if the remaining types are also considered this will have to be re-written.

Resolves: #81 