### PR TITLE
multiple og:type attributes

### DIFF
--- a/goose3/extractors/opengraph.py
+++ b/goose3/extractors/opengraph.py
@@ -33,8 +33,7 @@ class OpenGraphExtractor(BaseExtractor):
         metas = self.parser.getElementsByTag(node, 'meta')
 
         # Open Graph type that is supported. In theory it is possible
-        # that a page has multiple types, but we will only consider
-        # the first one.
+        # that a page has multiple types
         og_types = [
             self.parser.getAttribute(meta, 'content')
             for meta in metas
@@ -42,7 +41,8 @@ class OpenGraphExtractor(BaseExtractor):
                 and self.parser.getAttribute(meta, 'content'))
         ]
         if og_types:
-            og_type = og_types[0] + ":"
+            # make unique set of possible prefixes
+            og_types = tuple([x for x in set(og_types)])
 
         for meta in metas:
             attr = self.parser.getAttribute(meta, 'property')
@@ -50,7 +50,12 @@ class OpenGraphExtractor(BaseExtractor):
             if attr and value:
                 if attr.startswith("og:"):
                     opengraph_dict.update({attr.split(":", 1)[1]: value})
-                elif og_type and attr.startswith(og_type):
+                elif og_types and attr.startswith(og_types):
                     opengraph_dict.update({attr: value})
+
+        # add all the types in... if there are multiple
+        if len(og_types) > 1:
+            opengraph_dict.pop('type')
+            opengraph_dict['types'] = [x for x in sorted(og_types)]
 
         return opengraph_dict

--- a/goose3/extractors/opengraph.py
+++ b/goose3/extractors/opengraph.py
@@ -28,7 +28,6 @@ class OpenGraphExtractor(BaseExtractor):
 
     def extract(self):
         opengraph_dict = {}
-        og_type = None
         node = self.article.doc
         metas = self.parser.getElementsByTag(node, 'meta')
 
@@ -37,9 +36,10 @@ class OpenGraphExtractor(BaseExtractor):
         og_types = [
             self.parser.getAttribute(meta, 'content')
             for meta in metas
-            if (self.parser.getAttribute(meta, 'property') == "og:type"
-                and self.parser.getAttribute(meta, 'content'))
+            if (self.parser.getAttribute(meta, 'property') == "og:type" and
+                self.parser.getAttribute(meta, 'content'))
         ]
+
         if og_types:
             # make unique set of possible prefixes
             og_types = tuple([x for x in set(og_types)])

--- a/tests/data/opengraph/test_opengraph_types_mult.html
+++ b/tests/data/opengraph/test_opengraph_types_mult.html
@@ -1,0 +1,17 @@
+<html>
+    <head>
+      <meta property="og:url" content="http://example.com/article"/>
+      <meta property="og:type" content="article"/>
+      <meta property="og:title" content="This article contains a title"/>
+      <meta property="og:description" content="This is not a very good description">
+      <meta property="article:section" content="Awesome"/>
+      <meta property="og:type" content="article"/>
+      <meta property="article:published_time" content="Sun Nov 23 16:00:00 EDT 2014"/>
+
+      <meta property="og:type" content="image"/>
+      <meta property="image:width" content="100"/>
+      <meta property="image:height" content="150"/>
+    </head>
+    <body>
+    </body>
+</html>

--- a/tests/data/opengraph/test_opengraph_types_mult.json
+++ b/tests/data/opengraph/test_opengraph_types_mult.json
@@ -1,0 +1,16 @@
+{
+    "url": "http://exemple.com/article",
+    "expected": {
+        "opengraph": {
+            "url": "http://example.com/article",
+            "types": ["article", "image"],
+            "description": "This is not a very good description",
+            "title": "This article contains a title",
+            "article:section": "Awesome",
+            "article:published_time": "Sun Nov 23 16:00:00 EDT 2014",
+            "image:width": "100",
+            "image:height": "150"
+        },
+        "publish_date": "Sun Nov 23 16:00:00 EDT 2014"
+    }
+}

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -39,3 +39,7 @@ class TestOpenGraph(TestExtractionBase):
     def test_opengraph_type_none(self):
         article = self.getArticle()
         self.runArticleAssertions(article=article, fields=['opengraph'])
+
+    def test_opengraph_types_mult(self):
+        article = self.getArticle()
+        self.runArticleAssertions(article=article, fields=['opengraph'])


### PR DESCRIPTION
* Add ability to pull multiple og:type in open-graphs. 
* Add sub-types such as `image:width` into the open-graph dictionary

@dlrobertson this helps get closer to #84