### PR TITLE
Set requests encoding

### DIFF
--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -272,7 +272,7 @@ class Crawler(object):
             encodings = get_encodings_from_content(response.text)
             if len(encodings) > 0:
                 self.article._meta_encoding = encodings[0]
-                response.encoding = self.article._meta_encoding[0]
+                response.encoding = encodings[0]
                 html = response.text
             else:
                 self.article._meta_encoding = encodings

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -272,6 +272,7 @@ class Crawler(object):
             encodings = get_encodings_from_content(response.text)
             if len(encodings) > 0:
                 self.article._meta_encoding = encodings[0]
+                response.encoding = self.article._meta_encoding[0]
                 html = response.text
             else:
                 self.article._meta_encoding = encodings

--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -263,7 +263,7 @@ class Crawler(object):
 
         # fetch HTML
         response = self.fetcher.fetch_obj(parsing_candidate.url)
-        if response.encoding != 'ISO-8859-1':  # shows that we don't actually know
+        if response.encoding != 'ISO-8859-1':  # requests has a good idea; use what it says
             # return response as a unicode string
             html = response.text
             self.article._meta_encoding = response.encoding


### PR DESCRIPTION
* Set the response encoding to the meta encoding if the requests library is unable to resolve the correct encoding; resolves #88 

@dlrobertson and @Andrew-Katcha this may resolve the issue with #83