### PR TITLE
version bump to 3.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Goose3
 
+### Version 3.1.6
+* Improved handling of page encoding [see PR #92](https://github.com/goose3/goose3/pull/92)
+* Improved author and published date extraction [see PR #93](https://github.com/goose3/goose3/pull/93) Thanks [@timoilya](https://github.com/timoilya)!
+* Added additional schema extractors for schema.org parser [see PR #89](https://github.com/goose3/goose3/pull/89)
+* Allow for pulling more then the first og:type data for Opengraph [see PR #90](https://github.com/goose3/goose3/pull/90)
+
 ### Version 3.1.5
 * Added additional date parsing [see PR #71](https://github.com/goose3/goose3/pull/71) Thanks [@dlrobertson](https://github.com/dlrobertson)!
 * Added datetime representation of the publish date `publish_datetime_utc` [see issue #72](https://github.com/goose3/goose3/issues/72)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,3 +149,5 @@ A special thanks to all the code contributors to goose3!
 [@nyanshell](https://github.com/nyanshell)
 [@dlrobertson](https://github.com/dlrobertson)
 [@jeffquach](https://github.com/jeffquach)
+[dust0x](https://github.com/dust0x)
+[@timoilya](https://github.com/timoilya)

--- a/goose3/version.py
+++ b/goose3/version.py
@@ -21,5 +21,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-version_info = (3, 1, 5)  # pylint: disable=C0103
+version_info = (3, 1, 6)  # pylint: disable=C0103
 __version__ = ".".join([str(x) for x in version_info])


### PR DESCRIPTION
* Improved handling of page encoding [see PR #92](https://github.com/goose3/goose3/pull/92)
* Improved author and published date extraction [see PR #93](https://github.com/goose3/goose3/pull/93) Thanks [@timoilya](https://github.com/timoilya)!
* Added additional schema extractors for schema.org parser [see PR #89](https://github.com/goose3/goose3/pull/89)
* Allow for pulling more then the first og:type data for Opengraph [see PR #90](https://github.com/goose3/goose3/pull/90)