### PR TITLE
ensure resources included in .tar.gz build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include goose3/resources *


### PR DESCRIPTION
Found that the tar.gz builds do not include the resources folder. This fixes that issue. 