### PR TITLE
Fix a bug when int publish date lead to TypeError

### DIFF
--- a/goose3/crawler.py
+++ b/goose3/crawler.py
@@ -337,7 +337,7 @@ class Crawler:
             if publish_datetime.tzinfo:
                 return publish_datetime.astimezone(tzutc())
             return publish_datetime
-        except (ValueError, OverflowError):
+        except (ValueError, OverflowError, TypeError):
             logger.warning("Publish date %s could not be resolved to UTC", self.article.publish_date)
             return None
 


### PR DESCRIPTION
See https://www.linkedin.com/pulse/you-getting-raise-year-cnbc/

`self.publishdate_extractor.extract()` extracts `int` publish date - `1676551869000`. Because of that `dateutil` failes to parse it and raises exception - `TypeError: Parser must be a string or character stream, not int`. Which lead to exception raise by `self._publish_date_to_utc()`, which lead to entire parsing fail.

I don't sure if catching this `TypeError` is the best way to fix it. Perhaps it is best to fix `self.publishdate_extractor.extract()` so that it shouldn't return `int` result at all. 