### PR TITLE
return context instead of content when content is list

### DIFF
--- a/goose3/extractors/schema.py
+++ b/goose3/extractors/schema.py
@@ -39,7 +39,7 @@ class SchemaExtractor(BaseExtractor):
                             context["@context"] in ("https://schema.org", "http://schema.org")
                             and context["@type"] in KNOWN_SCHEMA_TYPES
                         ):
-                            return content
+                            return context
                 elif isinstance(content, dict):
                     if (
                         content["@context"] in ("https://schema.org", "http://schema.org")


### PR DESCRIPTION
To my knowledge, "schema" should be a dictionary rather than a list.



