### PR TITLE
Bug Fix: Key error in author extraction

### DIFF
--- a/goose3/extractors/authors.py
+++ b/goose3/extractors/authors.py
@@ -70,7 +70,7 @@ class AuthorsExtractor(BaseExtractor):
                 schema_authors = [schema_authors]
             for author in schema_authors:
                 if isinstance(author, dict):
-                    authors.append(author["name"])
+                    authors.append(author.get("name", ""))
                 else:
                     authors.append(author)
         return authors


### PR DESCRIPTION
Please find the traceback attached below.

```
  article_t = g.extract(url=url)
  File "/usr/local/lib/python3.10/dist-packages/goose3/__init__.py", line 125, in extract
    return self.__crawl(crawl_candidate)
  File "/usr/local/lib/python3.10/dist-packages/goose3/__init__.py", line 153, in __crawl
    return crawler_wrapper(self.config.parser_class, parsers, crawl_candidate)
  File "/usr/local/lib/python3.10/dist-packages/goose3/__init__.py", line 141, in crawler_wrapper
    article = crawler.crawl(crawl_candidate)
  File "/usr/local/lib/python3.10/dist-packages/goose3/crawler.py", line 135, in crawl
    return self.process(raw_html, parse_candidate.url, parse_candidate.link_hash)
  File "/usr/local/lib/python3.10/dist-packages/goose3/crawler.py", line 183, in process
    self.article._authors = self.authors_extractor.extract()
  File "/usr/local/lib/python3.10/dist-packages/goose3/extractors/authors.py", line 27, in extract
    authors_from_schema = self.__get_authors_from_schema()
  File "/usr/local/lib/python3.10/dist-packages/goose3/extractors/authors.py", line 73, in __get_authors_from_schema
    authors.append(author["name"])
KeyError: 'name'
```