### PR TITLE
Add Japanese tokenizer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ To install just the dependencies for a single language:
 
     pip install goose3[chinese]
     pip install goose3[arabic]
+    pip install goose3[japanese]
 
 To install from source:
 
@@ -258,6 +259,26 @@ class.
     경기도 용인에 자리 잡은 민간 시험인증 전문기업 ㈜디지털이엠씨(www.digitalemc.com).
     14년째 세계 각국의 통신·안전·전파 규격 시험과 인증 한 우물만 파고 있는 이 회사 박채규 대표가 만나기로 한 주인공이다.
     그는 전기전자·무선통신·자동차 전장품 분야에
+
+
+Goose in Japanese
+--------------------------------------------------------------------------------
+
+In order to use Goose in Japanese you have to use the StopWordsJapanese
+class.
+
+.. code-block:: python
+
+    >>> from goose3 import Goose
+    >>> from goose3.text import StopWordsJapanese
+    >>> url='https://www.cnn.co.jp/usa/35237967.html'
+    >>> g = Goose({'stopwords_class':StopWordsJapanese})
+    >>> article = g.extract(url=url)
+    >>> print article.cleaned_text[:150]
+    イリーナ・ザルツカさん（２３）。今年８月、ノースカロライナ州シャーロットのライトレール列車に乗っていた際に刺されて死亡した/Iryna Zarutska/Instagram
+
+    （ＣＮＮ） 米ノースカロライナ州シャーロット中心部から数キロ離れたスケイリーバーク駅。駅に到着した深夜の列車に乗り込んだとき
+
 
 TODO
 --------------------------------------------------------------------------------

--- a/goose3/text.py
+++ b/goose3/text.py
@@ -24,6 +24,7 @@ import re
 import string
 import warnings
 from typing import Dict, Set
+import unicodedata
 
 from goose3.utils import FileHelper, deprecated
 from goose3.utils.constants import CAMEL_CASE_DEPRICATION
@@ -230,3 +231,22 @@ class StopWordsKorean(StopWords):
         stats.set_stopword_count(len(overlapping_stopwords))
         stats.set_stop_words(overlapping_stopwords)
         return stats
+
+
+class StopWordsJapanese(StopWords):
+    """Japanese segmentation"""
+
+    def __init__(self, language="ja"):
+        super().__init__(language)
+
+    @staticmethod
+    def candidate_words(stripped_input):
+        try:
+            from fugashi import Tagger
+        except ImportError:
+            warnings.warn("fugashi is not installed. To use Japanese, one must install the fugashi[unidic-lite] package")
+            return []
+
+        tagger = Tagger()
+        s = unicodedata.normalize("NFKC", stripped_input)
+        return [el.surface for el in tagger(s)]

--- a/requirements/python-dev
+++ b/requirements/python-dev
@@ -2,3 +2,4 @@ flake8
 requests_mock
 jieba
 nltk
+fugashi[unidic-lite]

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,9 +54,11 @@ python_requires = >=3.7
 [options.extras_require]
 chinese = jieba
 arabic = nltk
+japanese = fugashi[unidic-lite]
 all =
     jieba
     nltk
+    fugashi[unidic-lite]
 
 [options.packages.find]
 exclude = tests


### PR DESCRIPTION
Fixes #211

Uses https://github.com/polm/fugashi library. The wheel is about 250 MB, hence the dependency is optional.