### PR TITLE
Small bugs found and fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ ENV/
 # JetBrains
 .idea
 .vscode/settings.json
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/goose3/__init__.py
+++ b/goose3/__init__.py
@@ -117,8 +117,6 @@ class Goose:
             Article: Representation of the article contents including other parsed and extracted metadata"""
         if not url and not raw_html:
             raise ValueError("Either url or raw_html should be provided")
-        if url is None and raw_html is None:
-            raise ValueError("Either url or raw_html should be provided")
         crawl_candidate = CrawlCandidate(self.config, url, raw_html)
         return self.__crawl(crawl_candidate)
 

--- a/goose3/cleaners.py
+++ b/goose3/cleaners.py
@@ -211,7 +211,7 @@ class DocumentCleaner:
                         nodes_to_remove.append(next_sibling_node)
                         self.parser.set_attribute(next_sibling_node, attr="grv-usedalready", value="yes")
                         next_sib = self.parser.next_sibling(next_sibling_node)
-                        previous_sibling_node = next_sib if next_sib is not None else None
+                        next_sibling_node = next_sib if next_sib is not None else None
 
             # otherwise
             else:

--- a/goose3/extractors/content.py
+++ b/goose3/extractors/content.py
@@ -280,10 +280,7 @@ class ContentExtractor(BaseExtractor):
         number_of_links = float(len(links))
         link_divisor = float(number_of_link_words / words_number)
         score = float(link_divisor * number_of_links)
-        if score >= 1.0:
-            return True
-        return False
-        # return True if score > 1.0 else False
+        return score >= 1.0
 
     def get_score(self, node):
         """returns the gravityScore as an integer from this node"""
@@ -313,9 +310,7 @@ class ContentExtractor(BaseExtractor):
                 self.parser.remove(para)
 
         sub_paragraphs2 = self.parser.get_elements_by_tag(elm, tag="p")
-        if not sub_paragraphs2 and elm.tag != "td":
-            return True
-        return False
+        return not sub_paragraphs2 and elm.tag != "td"
 
     def is_nodescore_threshold_met(self, node, elm):
         top_node_score = self.get_score(node)

--- a/goose3/extractors/images.py
+++ b/goose3/extractors/images.py
@@ -152,7 +152,7 @@ class ImageExtractor(BaseExtractor):
             src = local_image.src
             file_extension = local_image.file_extension
 
-            if file_extension != ".gif" or file_extension != "NA":
+            if file_extension != ".gif" and file_extension != "NA":
                 if (depth_level >= 1 and local_image.width > 300) or depth_level < 1:
                     if not self.is_banner_dimensions(width, height):
                         if width > min_width:

--- a/goose3/extractors/publishdate.py
+++ b/goose3/extractors/publishdate.py
@@ -269,7 +269,7 @@ class PublishDateExtractor(BaseExtractor):
         if self.article.schema and "datePublished" in self.article.schema:
             date = self.article.schema["datePublished"]
 
-            if type(date) == int or type(date) == float:
+            if isinstance(date, (int, float)):
                 t = None
 
                 try:

--- a/goose3/network.py
+++ b/goose3/network.py
@@ -27,7 +27,7 @@ class NetworkError(RuntimeError):
     def __init__(self, status_code, reason):
         self.reason = reason
         self.status_code = status_code
-        self.message = f"NetworkError: status code: {reason}; reason: {status_code}"
+        self.message = f"NetworkError: status code: {status_code}; reason: {reason}"
         super().__init__(self.message)
 
 

--- a/goose3/parsers.py
+++ b/goose3/parsers.py
@@ -191,28 +191,15 @@ class Parser:
 
     @classmethod
     def previous_siblings(cls, node):
-        nodes = []
-        for _, val in enumerate(node.itersiblings(preceding=True)):
-            nodes.append(val)
-        return nodes
+        return list(node.itersiblings(preceding=True))
 
     @classmethod
     def previous_sibling(cls, node):
-        nodes = []
-        for idx, val in enumerate(node.itersiblings(preceding=True)):
-            nodes.append(val)
-            if idx == 0:
-                break
-        return nodes[0] if nodes else None
+        return next(node.itersiblings(preceding=True), None)
 
     @classmethod
     def next_sibling(cls, node):
-        nodes = []
-        for idx, val in enumerate(node.itersiblings(preceding=False)):
-            nodes.append(val)
-            if idx == 0:
-                break
-        return nodes[0] if nodes else None
+        return next(node.itersiblings(preceding=False), None)
 
     @classmethod
     def is_text_node(cls, node):


### PR DESCRIPTION

  Bugs
  - network.py — swapped status_code/reason labels in NetworkError message
  - cleaners.py — next-sibling inlining loop assigned to wrong variable, causing
   it to run at most once
  - extractors/images.py — or → and; the condition was tautologically true, so
  .gif/NA images were never skipped

  Simplifications (no behavior change)
  - __init__.py — drop redundant duplicate ValueError check
  - parsers.py — collapse previous_siblings/previous_sibling/next_sibling to
  one-liners using list() / next(..., None)
  - extractors/publishdate.py — type() == → isinstance()
  - extractors/content.py — collapse two verbose if x: return True; return False
   blocks

  Test plan

  - pytest — all 250 pass