### PR TITLE
fix quadratic search to linear

### DIFF
--- a/goose3/extractors/content.py
+++ b/goose3/extractors/content.py
@@ -152,11 +152,11 @@ class ContentExtractor(BaseExtractor):
         minimum_stopword_count = 5
         max_stepsaway_from_node = 3
 
-        nodes = self.walk_siblings(node)
-        for current_node in nodes:
-            # p
-            current_node_tag = self.parser.get_tag(current_node)
-            if current_node_tag == para:
+        # Iterate preceding siblings lazily so we bail after `max_stepsaway_from_node`
+        # paragraphs without scanning the entire prior subtree (was O(N) per call,
+        # making `calculate_best_node` O(N^2) for documents with many paragraphs).
+        for current_node in node.itersiblings(preceding=True):
+            if self.parser.get_tag(current_node) == para:
                 if steps_away >= max_stepsaway_from_node:
                     return False
                 para_text = self.parser.get_text(current_node)


### PR DESCRIPTION

  In is_boostable, replaced self.walk_siblings(node) with
  node.itersiblings(preceding=True).

  - walk_siblings eagerly builds a full list of every preceding sibling before
  returning — O(N) per call.
  - itersiblings is a lazy generator — yields one sibling at a time.
  - is_boostable only ever needs ~3 siblings (it returns after
  max_stepsaway_from_node = 3), so the lazy iterator stops early instead of
  walking thousands of nodes.

  calculate_best_node calls is_boostable once per text node:
  - Before: N × O(N) = O(N²)
  - After: N × O(1) = O(N)

  16,000 tags: 45s → 1.6s (~28× faster).

fixes #212 